### PR TITLE
Fixes on hackathon updates

### DIFF
--- a/components/MessageBanner.tsx
+++ b/components/MessageBanner.tsx
@@ -6,9 +6,10 @@ interface MessageBannerProps {
 }
 
 const messages = {
-  en: "NERO Chain x AKINDO Wavehack is coming! More info soon!",
-  ja: "NERO Chain × AKINDO Wavehack、まもなく開催！詳細は近日公開予定です。お楽しみに！"
+  en: "🚀 NERO Chain x AKINDO WaveHack has officially started! Join now: https://app.akindo.io/wave-hacks/VwQGxPraOF0zZJkX",
+  ja: "🚀 NERO Chain × AKINDO WaveHackがついに開幕！今すぐ参加しよう：https://app.akindo.io/wave-hacks/VwQGxPraOF0zZJkX"
 };
+
 
 const MessageBanner: React.FC<MessageBannerProps> = ({ message }) => {
   const router = useRouter();

--- a/components/SidebarResources.tsx
+++ b/components/SidebarResources.tsx
@@ -127,18 +127,30 @@ const resourceLinksMap: Record<string, ResourceLink[]> = {
     {
       title: "Check the AA Plaform Website",
       url: "https://aa-platform.nerochain.io/user/login"
+    },
+    {
+      title: "Check the AA Platform Walkthrough",
+      url: "https://www.youtube.com/watch?v=GyVSVmyf36o&ab_channel=NEROChain"
     }
   ],
   '/en/developer-tools/aa-platform/getting-started': [
     {
       title: "Check the AA Plaform Website",
       url: "https://aa-platform.nerochain.io/user/login"
+    },
+    {
+      title: "Check the AA Platform Walkthrough",
+      url: "https://www.youtube.com/watch?v=GyVSVmyf36o&ab_channel=NEROChain"
     }
   ],
   '/en/developer-tools/aa-platform/managing-api-keys': [
     {
       title: "Check the AA Plaform Website",
       url: "https://aa-platform.nerochain.io/user/login"
+    },
+    {
+      title: "Check the AA Platform Walkthrough",
+      url: "https://www.youtube.com/watch?v=GyVSVmyf36o&ab_channel=NEROChain"
     }
   ],
   '/en/developer-tools/aa-platform/configuring-policies': [
@@ -151,12 +163,20 @@ const resourceLinksMap: Record<string, ResourceLink[]> = {
     {
       title: "Check the AA Plaform Website",
       url: "https://aa-platform.nerochain.io/user/login"
+    },
+    {
+      title: "Check the AA Platform Walkthrough",
+      url: "https://www.youtube.com/watch?v=GyVSVmyf36o&ab_channel=NEROChain"
     }
   ],
   '/en/developer-tools/aa-platform/integration-and-best-practices': [
     {
       title: "Check the AA Plaform Website",
       url: "https://aa-platform.nerochain.io/user/login"
+    },
+    {
+      title: "Check the AA Platform Walkthrough",
+      url: "https://www.youtube.com/watch?v=GyVSVmyf36o&ab_channel=NEROChain"
     }
   ],
   '/en/developer-tools/aa-platform/troubleshooting': [
@@ -448,30 +468,45 @@ const resourceLinksMap: Record<string, ResourceLink[]> = {
     {
       title: "AA プラットフォームウェブサイトを確認する",
       url: "https://aa-platform.nerochain.io/user/login"
+    },{
+      title: "AAプラットフォームのチュートリアルを確認しよう",
+      url: "https://www.youtube.com/watch?v=GyVSVmyf36o&ab_channel=NEROChain"
     }
   ],
   '/ja/developer-tools/aa-platform/getting-started': [
     {
       title: "AA プラットフォームウェブサイトを確認する",
       url: "https://aa-platform.nerochain.io/user/login"
+    },{
+      title: "AAプラットフォームのチュートリアルを確認しよう",
+      url: "https://www.youtube.com/watch?v=GyVSVmyf36o&ab_channel=NEROChain"
     }
   ],
   '/ja/developer-tools/aa-platform/managing-api-keys': [
     {
       title: "AA プラットフォームウェブサイトを確認する",
       url: "https://aa-platform.nerochain.io/user/login"
+    },{
+      title: "AAプラットフォームのチュートリアルを確認しよう",
+      url: "https://www.youtube.com/watch?v=GyVSVmyf36o&ab_channel=NEROChain"
     }
   ],
   '/ja/developer-tools/aa-platform/configuring-policies': [
     {
       title: "AA プラットフォームウェブサイトを確認する",
       url: "https://aa-platform.nerochain.io/user/login"
+    },{
+      title: "AAプラットフォームのチュートリアルを確認しよう",
+      url: "https://www.youtube.com/watch?v=GyVSVmyf36o&ab_channel=NEROChain"
     }
   ],
   '/ja/developer-tools/aa-platform/payment-management': [
     {
       title: "AA プラットフォームウェブサイトを確認する",
       url: "https://aa-platform.nerochain.io/user/login"
+    },{
+      title: "AAプラットフォームのチュートリアルを確認しよう",
+      url: "https://www.youtube.com/watch?v=GyVSVmyf36o&ab_channel=NEROChain"
     }
   ],
   '/ja/developer-tools/aa-platform/integration-and-best-practices': [

--- a/pages/en/developer-tools/accessEntryPoint.mdx
+++ b/pages/en/developer-tools/accessEntryPoint.mdx
@@ -15,6 +15,7 @@ import PageFeedback from '../../../components/PageFeedback'
 | Explorer        | https://neroscan.io                                                                     |
 | Connect Wallet  | [Click here to connect your wallet to NERO Mainnet](https://chainlist.org/?search=Nero) |
 | Node Web Socket | wss://ws.nerochain.io                                                                   |
+| Subgraph SandBox | https://subgraph.mainnet.nero.metaborong.com/                                          |
 
 ### AA URLs
 
@@ -56,6 +57,7 @@ import PageFeedback from '../../../components/PageFeedback'
 | Explorer        | https://testnet.neroscan.io                                                                           |
 | Connect Wallet  | [Click here to connect your wallet to NERO Testnet](https://chainlist.org/?search=Nero&testnets=true) |
 | Node Web Socket | wss://ws-testnet.nerochain.io                                                                   |
+| Subgraph SandBox | https://subgraph.testnet.nero.metaborong.com/                                          |
 
 ### AA URLs
 

--- a/pages/ja/developer-tools/accessEntryPoint.mdx
+++ b/pages/ja/developer-tools/accessEntryPoint.mdx
@@ -15,6 +15,7 @@ import PageFeedback from '../../../components/PageFeedback'
 | エクスプローラー        | https://neroscan.io                                                                     |
 | ウォレット接続  | [ここをクリックしてウォレットをNEROメインネットに接続](https://chainlist.org/?search=Nero) |
 | ノードWebソケット | wss://ws.nerochain.io                                                                   |
+| サブグラフ・サンドボックス| https://subgraph.mainnet.nero.metaborong.com/                                          |
 
 ### AA URL
 
@@ -56,6 +57,7 @@ import PageFeedback from '../../../components/PageFeedback'
 | エクスプローラー        | https://testnet.neroscan.io                                                                           |
 | ウォレット接続  | [ここをクリックしてウォレットをNEROテストネットに接続](https://chainlist.org/?search=Nero&testnets=true) |
 | ノードWebソケット | wss://ws-testnet.nerochain.io                                                                   |
+| サブグラフ・サンドボックス | https://subgraph.testnet.nero.metaborong.com/                                          |
 
 ### AA URL
 


### PR DESCRIPTION
# Brief
This PR updates the documentation with information about the NERO Chain x AKINDO Wavehack and adds Metaborong subgraph sandbox URLs to the network information sections. It also enhances the sidebar resources with AA Platform walkthrough video links.
## Activities
- Updated the message banner with official NERO Chain x AKINDO WaveHack announcement and participation link
- Added Metaborong subgraph sandbox URLs for both mainnet and testnet to the network information
- Added AA Platform walkthrough video links to all AA-related sidebar resources in both English and Japanese
## Evidences
- Message banner now shows "NERO Chain x AKINDO WaveHack has officially started!" with a link to join

![image](https://github.com/user-attachments/assets/e405be1b-5ef1-4836-bc0f-78bf5500ca7e)
![image](https://github.com/user-attachments/assets/d5e5131c-b758-4495-bcd6-1bcae958e753)


- Network information pages now include subgraph sandbox URLs:

![image](https://github.com/user-attachments/assets/c6b37770-8abd-4692-a164-bdef531ef202)
![image](https://github.com/user-attachments/assets/f1125b73-943e-4380-808a-2b8ccf2d9deb)


- Added YouTube walkthrough link (https://www.youtube.com/watch?v=GyVSVmyf36o) to multiple sidebar resource aa-platform sections in both English and Japanese

![image](https://github.com/user-attachments/assets/23e334d4-8efb-404f-aa9f-ab0c53ff9afa)
![image](https://github.com/user-attachments/assets/b91b8fc8-a908-41e4-8767-f69ca5b98b86)


Preview at: https://nerodocsv1.vercel.app/en


