### PR TITLE
feat: changes the banner message and makes the link clickable

### DIFF
--- a/components/MessageBanner.tsx
+++ b/components/MessageBanner.tsx
@@ -6,8 +6,16 @@ interface MessageBannerProps {
 }
 
 const messages = {
-  en: "🚀 NERO Chain x AKINDO WaveHack has officially started! Join now: https://app.akindo.io/wave-hacks/VwQGxPraOF0zZJkX",
-  ja: "🚀 NERO Chain × AKINDO WaveHackがついに開幕！今すぐ参加しよう：https://app.akindo.io/wave-hacks/VwQGxPraOF0zZJkX"
+  en: {
+    text: "🗾 Join us at NERO Chain's Tokyo WebX Side Event! Register now",
+    linkText: "here",
+    url: "https://lu.ma/e60eeg9g"
+  },
+  ja: {
+    text: "🗾 NERO ChainのTokyo WebXサイドイベントにご参加ください！",
+    linkText: "今すぐ登録",
+    url: "https://lu.ma/e60eeg9g"
+  }
 };
 
 
@@ -51,13 +59,32 @@ const MessageBanner: React.FC<MessageBannerProps> = ({ message }) => {
   }, [isVisible, isFading]);
 
   // Use provided message or fallback to localized message
-  const displayMessage = message || messages[locale as keyof typeof messages] || messages.en;
+  const messageData = messages[locale as keyof typeof messages] || messages.en;
 
   if (!isVisible) return null;
 
   return (
     <div className={`message-banner ${isFading ? 'fade-out' : ''}`}>
-      <span>{displayMessage}</span>
+      {message ? (
+        <span>{message}</span>
+      ) : (
+        <span>
+          {messageData.text}{' '}
+          <a 
+            href={messageData.url} 
+            target="_blank" 
+            rel="noopener noreferrer"
+            style={{ 
+              color: 'inherit', 
+              textDecoration: 'underline',
+              fontWeight: 'bold'
+            }}
+          >
+            {messageData.linkText}
+          </a>
+          !
+        </span>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
# Brief
This PR changes the Bannner message on the top of the docs page to our Dev Event for WebX (And removes the Akindo Wavehack one). Also, makes the link clickable so people can go directly to the page.

## Activities
- Changes the message to the updated version
- Makes it clickable

## Evidences

En version:
<img width="686" height="220" alt="image" src="https://github.com/user-attachments/assets/699b59fd-cfd4-426c-aa8d-b55b5fc4e5fe" />

Jp version:
<img width="602" height="111" alt="image" src="https://github.com/user-attachments/assets/c4a5ca6e-70d1-4268-8f25-4a9b683d26f8" />


