### PR TITLE
fix(agents): MCP manifest.json + JSON 404 fallback

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -154,6 +154,10 @@
     ],
     "rewrites": [
       {
+        "source": "/api/**",
+        "destination": "/404.json"
+      },
+      {
         "source": "/ja/**",
         "destination": "/ja/index.html"
       },

--- a/public/.well-known/mcp/manifest.json
+++ b/public/.well-known/mcp/manifest.json
@@ -1,0 +1,194 @@
+{
+  "$schema": "https://modelcontextprotocol.io/schemas/server-manifest.json",
+  "schemaVersion": "1.0.0",
+  "name": "io.nerochain/docs",
+  "displayName": "NERO Chain Documentation",
+  "description": "MCP server for NERO Chain documentation — a Layer-1 blockchain with native account abstraction (ERC-4337), paymaster-based gas sponsorship, and Web2-style authentication. Seven tools covering search, page retrieval, Paymaster JSON-RPC method lookup, curated code examples, FAQ, and structured integration configuration. 143 docs:// resources (EN + JA) plus four ui:// MCP Apps templates.",
+  "version": "1.0.0",
+  "protocolVersion": "2025-06-18",
+  "author": "NERO Chain",
+  "license": "MIT",
+  "homepage": "https://docs.nerochain.io/en/ai-resources",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nerochain/Nero-docs",
+    "subfolder": "mcp-server"
+  },
+  "transport": {
+    "type": "streamable-http",
+    "url": "https://docs-mcp.nerochain.io"
+  },
+  "remotes": [
+    {
+      "transport_type": "streamable-http",
+      "url": "https://docs-mcp.nerochain.io"
+    }
+  ],
+  "authentication": { "type": "none" },
+  "capabilities": {
+    "tools": true,
+    "resources": true,
+    "mcpApps": true,
+    "ui": true
+  },
+  "tools": [
+    {
+      "name": "search_docs",
+      "description": "Full-text BM25 search across NERO Chain documentation pages (EN + JA). Returns ranked hits with URL, title, section, summary.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "query": { "type": "string" },
+          "locale": { "type": "string", "enum": ["en", "ja"] },
+          "section": { "type": "string" },
+          "limit": { "type": "integer", "default": 8 }
+        },
+        "required": ["query"]
+      },
+      "_meta": {
+        "ui": { "resourceUri": "ui://nero-docs/search-results" }
+      }
+    },
+    {
+      "name": "get_page",
+      "description": "Fetch full markdown of a NERO docs page by URL path.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "path": { "type": "string" },
+          "locale": { "type": "string", "enum": ["en", "ja"] }
+        },
+        "required": ["path"]
+      },
+      "_meta": {
+        "ui": { "resourceUri": "ui://nero-docs/page-preview" }
+      }
+    },
+    {
+      "name": "list_sections",
+      "description": "Return navigation tree of NERO Chain docs.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "locale": { "type": "string", "enum": ["en", "ja"], "default": "en" }
+        }
+      },
+      "_meta": {
+        "ui": { "resourceUri": "ui://nero-docs/embed" }
+      }
+    },
+    {
+      "name": "get_api_method",
+      "description": "Return signature + examples for a Paymaster JSON-RPC method (pm_supported_tokens, pm_sponsor_userop, pm_entrypoints).",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "method": {
+            "type": "string",
+            "enum": ["pm_supported_tokens", "pm_sponsor_userop", "pm_entrypoints"]
+          }
+        },
+        "required": ["method"]
+      },
+      "_meta": {
+        "ui": { "resourceUri": "ui://nero-docs/api-method" }
+      }
+    },
+    {
+      "name": "get_code_example",
+      "description": "Return curated NERO integration snippet for 21 topics: quickstart, providers-setup, wallet-hook, builder-with-paymaster-hook, send-gasless-tx, send-userop, batch-transactions, erc20-transfer, nft-mint, staking, integrate-aa-wallet, web3auth-login-methods, nextjs-ssr-setup, fetch-balance, fetch-price, check-supported-tokens, complete-wallet-component, line-miniapp, error-handling, deploy-contract-hardhat, deploy-contract-remix.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "topic": { "type": "string" }
+        },
+        "required": ["topic"]
+      },
+      "_meta": {
+        "ui": { "resourceUri": "ui://nero-docs/page-preview" }
+      }
+    },
+    {
+      "name": "get_faq",
+      "description": "Return NERO Chain FAQ entries, optionally filtered by topic.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "topic": { "type": "string" },
+          "locale": { "type": "string", "enum": ["en", "ja"], "default": "en" }
+        }
+      },
+      "_meta": {
+        "ui": { "resourceUri": "ui://nero-docs/page-preview" }
+      }
+    },
+    {
+      "name": "get_integration_config",
+      "description": "Structured JSON reference for NERO Chain integration: networks (testnet/mainnet), contracts (EntryPoint, SimpleAccountFactory, staking), paymaster payment types, env vars, Web3Auth setup, security rules.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "topic": {
+            "type": "string",
+            "enum": ["all", "networks", "testnet", "mainnet", "contracts", "paymaster-types", "env-vars", "web3auth", "security"]
+          },
+          "network": { "type": "string", "enum": ["testnet", "mainnet"] }
+        }
+      },
+      "_meta": {
+        "ui": { "resourceUri": "ui://nero-docs/embed" }
+      }
+    }
+  ],
+  "resources": [
+    {
+      "uri": "ui://nero-docs/search-results",
+      "name": "NERO Docs — search results view",
+      "description": "Compact HTML list of search hits for rendering inline in an MCP-Apps-capable chat UI.",
+      "mimeType": "text/html+skybridge"
+    },
+    {
+      "uri": "ui://nero-docs/page-preview",
+      "name": "NERO Docs — page preview",
+      "description": "Preview panel for a single doc page (title, section, summary, link, truncated markdown).",
+      "mimeType": "text/html+skybridge"
+    },
+    {
+      "uri": "ui://nero-docs/api-method",
+      "name": "NERO Docs — API method card",
+      "description": "Reference card for a Paymaster JSON-RPC method: signature, params, return shape, docs link.",
+      "mimeType": "text/html+skybridge"
+    },
+    {
+      "uri": "ui://nero-docs/embed",
+      "name": "NERO Docs — embed",
+      "description": "Shell that links to the AI resources hub. Used when no specific UI applies.",
+      "mimeType": "text/html+skybridge"
+    }
+  ],
+  "resourceTemplates": [
+    {
+      "uriTemplate": "docs:///{locale}/{path}",
+      "name": "NERO docs page",
+      "description": "Full markdown of any NERO docs page. locale ∈ {en, ja}. 143 resources total.",
+      "mimeType": "text/markdown"
+    }
+  ],
+  "provider": {
+    "name": "NERO Chain",
+    "url": "https://nerochain.io",
+    "documentationUrl": "https://docs.nerochain.io/en/ai-resources",
+    "contact": "contact@nerochain.io"
+  },
+  "tags": [
+    "blockchain",
+    "ethereum",
+    "account-abstraction",
+    "erc-4337",
+    "paymaster",
+    "layer-1",
+    "web3",
+    "developer-docs",
+    "documentation"
+  ]
+}

--- a/vercel.json
+++ b/vercel.json
@@ -49,6 +49,11 @@
       "source": "/ja/:path+",
       "has": [{ "type": "header", "key": "accept", "value": "text/markdown" }],
       "destination": "/ja/:path+.md"
+    },
+    {
+      "source": "/api/:path+",
+      "missing": [{ "type": "header", "key": "accept", "value": "text/html" }],
+      "destination": "/404.json"
     }
   ],
   "headers": [


### PR DESCRIPTION
# Brief 

Closes the three biggest code-level gaps from the latest orank scan of `docs.nerochain.io` (73 → targeting ~85).

## What orank said

### ❌ MCP manifest (−4 pts, warning)
> MCP endpoint found at /.well-known/mcp/manifest.json but response is not valid JSON

Previously that URL hit Firebase's SPA catch-all rewrite and served `/index.html`. The Firebase headers config applies `Content-Type: application/json` to `/.well-known/**.json`, so orank's parser received JSON-mime-typed HTML and threw `SyntaxError`. The parser failure cascaded into the next finding.

### ❌ MCP Apps support (−10 pts, fail)
> No MCP Apps support detected (no ui:// resources or tool UI metadata)

The live MCP server at `docs-mcp.nerochain.io` DOES expose 4 `ui://` resources with `text/html+skybridge` mime and 7 tools with `_meta.ui.resourceUri`. The problem: orank's audit path reads the manifest first — when manifest parse fails, it never opens an MCP session to verify.

### ❌ JSON error responses (−4 pts, fail)
> API does not return JSON error responses (or no API detected)

Generic `/api/*` probes hit the SPA catch-all → HTML 404. Orank expects structured JSON.

## Fix

**1. Ship `public/.well-known/mcp/manifest.json`** (new file, 180 lines) — proper MCP manifest with `$schema`, `protocolVersion`, `transport`, `capabilities.mcpApps: true`, **all 7 tools with `_meta.ui.resourceUri` inline**, all 4 `ui://` resources with mime + description, `resourceTemplates` for `docs:///`, provider info, tags. Orank can now verify MCP Apps support from the manifest alone without opening an MCP session.

**2. `/api/**` → `/404.json`** in both `firebase.json` and `vercel.json` (Vercel guarded by `missing: accept: text/html` so browsers still get HTML 404s). Real `/api/openapi.{yaml,json}` files are served first (static-file priority), so the fallback only fires for actual missing paths.

## Expected score movement

| Gap | Points | Fixed? |
|---|---|---|
| MCP manifest invalid JSON | −4 | ✅ |
| MCP Apps support | −10 | ✅ (cascaded from manifest) |
| JSON error responses | −4 | ✅ |
| Use-case search | −6 | ⚠️ Out of scope (SEO / content marketing) |
| Direct lookup (webhooks) | −4 | ⚠️ Out of scope (NERO doesn't have webhooks; it's a blockchain) |

**~18 points recoverable on next rescan.**
